### PR TITLE
wrong loadout message

### DIFF
--- a/code/game/objects/items/loadout_beacons.dm
+++ b/code/game/objects/items/loadout_beacons.dm
@@ -1375,7 +1375,7 @@ GLOBAL_LIST_EMPTY(loadout_boxes)
 /// Revolvers!
 
 /datum/loadout_box/detective
-	entry_tag = ".38 Detective Special"
+	entry_tag = ".22 Detective Special"
 	entry_flags = LOADOUT_FLAG_WASTER
 	entry_class = LOADOUT_CAT_REVOLVER
 	spawn_thing = /obj/item/storage/box/gun/revolver


### PR DESCRIPTION

## About The Pull Request
<!-- Write here -->
you call it a .38 revolver when its clearly a .22

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: loadout beacon calling it a .38 revolver when the gun is a .22 revolver
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
